### PR TITLE
API refactor

### DIFF
--- a/app-framework/connection/native/linux/connection_mgr.c
+++ b/app-framework/connection/native/linux/connection_mgr.c
@@ -508,16 +508,16 @@ app_mgr_connection_event_callback(module_data *m_data, bh_message_t msg)
     wasm_module_inst_t inst = wasm_app_data->wasm_module_inst;
     connection_event_t *conn_event =
         (connection_event_t *)bh_message_payload(msg);
-    int32 data_offset;
+    int64 data_offset;
 
     if (conn_event == NULL)
         return;
 
-    func_on_conn_data = wasm_runtime_lookup_function(
-        inst, "_on_connection_data", "(i32i32i32)");
+    func_on_conn_data =
+        wasm_runtime_lookup_function(inst, "_on_connection_data");
     if (!func_on_conn_data)
-        func_on_conn_data = wasm_runtime_lookup_function(
-            inst, "on_connection_data", "(i32i32i32)");
+        func_on_conn_data =
+            wasm_runtime_lookup_function(inst, "on_connection_data");
     if (!func_on_conn_data) {
         printf("Cannot find function on_connection_data\n");
         return;
@@ -539,7 +539,8 @@ app_mgr_connection_event_callback(module_data *m_data, bh_message_t msg)
     }
     else {
         data_offset = wasm_runtime_module_dup_data(inst, conn_event->data,
-                                                   conn_event->len);
+                                                   (uint64)conn_event->len);
+        bh_assert(data_offset <= UINT32_MAX);
         if (data_offset == 0) {
             const char *exception = wasm_runtime_get_exception(inst);
             if (exception) {

--- a/app-framework/sensor/native/sensor_mgr_ref.c
+++ b/app-framework/sensor/native/sensor_mgr_ref.c
@@ -34,16 +34,15 @@ app_mgr_sensor_event_callback(module_data *m_data, bh_message_t msg)
     if (payload == NULL)
         return;
 
-    func_onSensorEvent =
-        wasm_runtime_lookup_function(inst, "_on_sensor_event", "(i32i32i32)");
+    func_onSensorEvent = wasm_runtime_lookup_function(inst, "_on_sensor_event");
     if (!func_onSensorEvent)
-        func_onSensorEvent = wasm_runtime_lookup_function(
-            inst, "on_sensor_event", "(i32i32i32)");
+        func_onSensorEvent =
+            wasm_runtime_lookup_function(inst, "on_sensor_event");
     if (!func_onSensorEvent) {
         printf("Cannot find function on_sensor_event\n");
     }
     else {
-        int32 sensor_data_offset;
+        int64 sensor_data_offset;
         uint32 sensor_data_len;
 
         if (payload->data_fmt == FMT_ATTR_CONTAINER) {
@@ -55,8 +54,9 @@ app_mgr_sensor_event_callback(module_data *m_data, bh_message_t msg)
             return;
         }
 
-        sensor_data_offset =
-            wasm_runtime_module_dup_data(inst, payload->data, sensor_data_len);
+        sensor_data_offset = wasm_runtime_module_dup_data(
+            inst, payload->data, (uint64)sensor_data_len);
+        bh_assert(sensor_data_offset <= UINT32_MAX);
         if (sensor_data_offset == 0) {
             const char *exception = wasm_runtime_get_exception(inst);
             if (exception) {

--- a/app-framework/wgl/native/wgl_native_utils.c
+++ b/app-framework/wgl/native/wgl_native_utils.c
@@ -71,7 +71,7 @@ wgl_native_func_call(wasm_exec_env_t exec_env, WGLNativeFuncDef *funcs,
      * with pointer length equals to 1. Here validate the argv
      * buffer again but with its total length in bytes */
     if (!wasm_runtime_validate_native_addr(module_inst, argv,
-                                           argc * sizeof(uint32)))
+                                           (uint64)argc * sizeof(uint32)))
         return;
 
     while (func_def < func_def_end) {

--- a/app-framework/wgl/native/wgl_obj_wrapper.c
+++ b/app-framework/wgl/native/wgl_obj_wrapper.c
@@ -55,10 +55,10 @@ app_mgr_object_event_callback(module_data *m_data, bh_message_t msg)
         return;
 
     func_on_object_event =
-        wasm_runtime_lookup_function(inst, "_on_widget_event", "(i32i32)");
+        wasm_runtime_lookup_function(inst, "_on_widget_event");
     if (!func_on_object_event)
         func_on_object_event =
-            wasm_runtime_lookup_function(inst, "on_widget_event", "(i32i32)");
+            wasm_runtime_lookup_function(inst, "on_widget_event");
     if (!func_on_object_event) {
         printf("Cannot find function on_widget_event\n");
         return;

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/linux/display_indev.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/linux/display_indev.c
@@ -162,7 +162,7 @@ display_flush(wasm_exec_env_t exec_env, int32_t x1, int32_t y1, int32_t x2,
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     if (!wasm_runtime_validate_native_addr(module_inst, color,
-                                           sizeof(lv_color_t)))
+                                           (uint64_t)sizeof(lv_color_t)))
         return;
 
     monitor_flush(x1, y1, x2, y2, color);
@@ -195,8 +195,8 @@ display_input_read(wasm_exec_env_t exec_env, void *input_data_app)
     display_input_data *data_app = (display_input_data *)input_data_app;
     bool ret;
 
-    if (!wasm_runtime_validate_native_addr(module_inst, data_app,
-                                           sizeof(display_input_data)))
+    if (!wasm_runtime_validate_native_addr(
+            module_inst, data_app, (uint64_t)sizeof(display_input_data)))
         return false;
 
     lv_indev_data_t data = { 0 };
@@ -205,7 +205,7 @@ display_input_read(wasm_exec_env_t exec_env, void *input_data_app)
 
     data_app->point = data.point;
     data_app->user_data_offset =
-        wasm_runtime_addr_native_to_app(module_inst, data.user_data);
+        (uint32)wasm_runtime_addr_native_to_app(module_inst, data.user_data);
     data_app->state = data.state;
 
     return ret;
@@ -223,7 +223,7 @@ display_vdb_write(wasm_exec_env_t exec_env, void *buf, lv_coord_t buf_w,
     unsigned char *buf_xy = (unsigned char *)buf + 4 * x + 4 * y * buf_w;
 
     if (!wasm_runtime_validate_native_addr(module_inst, color,
-                                           sizeof(lv_color_t)))
+                                           (uint64_t)sizeof(lv_color_t)))
         return;
 
     *(lv_color_t *)buf_xy = *color;

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_indev.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_indev.c
@@ -40,7 +40,7 @@ display_flush(wasm_exec_env_t exec_env, int32_t x1, int32_t y1, int32_t x2,
     struct display_buffer_descriptor desc;
 
     if (!wasm_runtime_validate_native_addr(module_inst, color,
-                                           sizeof(lv_color_t)))
+                                           (uint64_t)sizeof(lv_color_t)))
         return;
 
     uint16_t w = x2 - x1 + 1;
@@ -72,7 +72,7 @@ display_input_read(wasm_exec_env_t exec_env, void *data)
     lv_indev_data_t *lv_data = (lv_indev_data_t *)data;
 
     if (!wasm_runtime_validate_native_addr(module_inst, lv_data,
-                                           sizeof(lv_indev_data_t)))
+                                           (uint64_t)sizeof(lv_indev_data_t)))
         return false;
 
     return touchscreen_read(lv_data);
@@ -90,7 +90,7 @@ display_vdb_write(wasm_exec_env_t exec_env, void *buf, lv_coord_t buf_w,
     uint8_t *buf_xy = (uint8_t *)buf + 3 * x + 3 * y * buf_w;
 
     if (!wasm_runtime_validate_native_addr(module_inst, color,
-                                           sizeof(lv_color_t)))
+                                           (uint64_t)sizeof(lv_color_t)))
         return;
 
     *buf_xy = color->red;


### PR DESCRIPTION
- Remove redundant argument `signature` from `wasm_runtime_lookup_function`
- Explicit type conversion for refactored APIs