### PR TITLE
Move some macros from WAMR to this project and fix typo

### DIFF
--- a/app-framework/connection/native/connection_lib.h
+++ b/app-framework/connection/native/connection_lib.h
@@ -13,6 +13,10 @@
 extern "C" {
 #endif
 
+#ifndef MAX_CONNECTION_PER_APP
+#define MAX_CONNECTION_PER_APP 3
+#endif
+
 /**
  * This file defines connection library which should be implemented by
  * different platforms

--- a/app-mgr/app-manager/app_manager.h
+++ b/app-mgr/app-manager/app_manager.h
@@ -15,6 +15,36 @@
 extern "C" {
 #endif
 
+/* Max app number of all modules */
+#ifndef MAX_APP_INSTALLATIONS
+#define MAX_APP_INSTALLATIONS 3
+#endif
+
+/* Default timer number in one app */
+#ifndef DEFAULT_TIMERS_PER_APP
+#define DEFAULT_TIMERS_PER_APP 20
+#endif
+
+/* Max timer number in one app */
+#ifndef MAX_TIMERS_PER_APP
+#define MAX_TIMERS_PER_APP 30
+#endif
+
+/* Max resource registration number in one app */
+#ifndef RESOURCE_REGISTRATION_NUM_MAX
+#define RESOURCE_REGISTRATION_NUM_MAX 16
+#endif
+
+/* Max length of resource/event url */
+#ifndef RESOURCE_EVENT_URL_LEN_MAX
+#define RESOURCE_EVENT_URL_LEN_MAX 256
+#endif
+
+/* Default watchdog interval in ms */
+#ifndef DEFAULT_WATCHDOG_INTERVAL
+#define DEFAULT_WATCHDOG_INTERVAL (3 * 60 * 1000)
+#endif
+
 #define APP_MGR_MALLOC wasm_runtime_malloc
 #define APP_MGR_FREE wasm_runtime_free
 

--- a/app-mgr/app-manager/resource_reg.c
+++ b/app-mgr/app-manager/resource_reg.c
@@ -158,7 +158,7 @@ am_register_resource(const char *url,
         r = r->next;
     }
 
-    if (strlen(url) > RESOUCE_EVENT_URL_LEN_MAX)
+    if (strlen(url) > RESOURCE_EVENT_URL_LEN_MAX)
         return false;
 
     if (register_num >= RESOURCE_REGISTRATION_NUM_MAX)


### PR DESCRIPTION
Some macros are defined in WAMR repo but are unrelated to WAMR,
we move them to this project instead.

And fix typo of `RESOUCE_EVENT_URL_LEN_MAX`, change it to
`RESOURCE_EVENT_URL_LEN_MAX`.