### PR TITLE
Update cmake min to 3.14 

### DIFF
--- a/samples/simple/CMakeLists.txt
+++ b/samples/simple/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project (simple)
 

--- a/test-tools/host-tool/CMakeLists.txt
+++ b/test-tools/host-tool/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 project (host-agent)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/wamr-sdk/app/CMakeLists.txt
+++ b/wamr-sdk/app/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.14)
 project(app-framework)
 
 SET (CMAKE_C_FLAGS "-O3")

--- a/wamr-sdk/runtime/CMakeLists.txt
+++ b/wamr-sdk/runtime/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.14)
 project(runtime-sdk)
 
 SET (CMAKE_C_FLAGS          "-O3")


### PR DESCRIPTION
3.14 is used and tested by linux mini-product

to fix

```
CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```